### PR TITLE
Add optional config parameter to adjust the page_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tap:
 
 To pull all surveys, the configuration parameters `access_token` and `start_date` are required.
 
-To pull responses or simplified responses for a survey, the configuration parameters `access_token`, `start_date`, and `survey_id` are required. The parameter `fetch_per_page` _(default: 50, max: 100)_ is optional to adjust the response-size for faster response times or larger batches thereby and reduced number of API-calls.
+To pull responses or simplified responses for a survey, the configuration parameters `access_token`, `start_date`, and `survey_id` are required. The parameter `fetch_page_size` _(default: 50, max: 100)_ is optional to adjust the response-size for faster response times or larger batches thereby and reduced number of API-calls.
 
 The [surveys](https://developer.surveymonkey.com/api/v3/#surveys-id-details) and [responses](https://developer.surveymonkey.com/api/v3/#surveys-id-responses-bulk) resources will pull data in the form described on the SurveyMonkey API docs.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tap:
 
 To pull all surveys, the configuration parameters `access_token` and `start_date` are required.
 
-To pull responses or simplified responses for a survey, the configuration parameters `access_token`, `start_date`, and `survey_id` are required. The parameter `fetch_page_size` _(default: 50, max: 100)_ is optional to adjust the response-size for faster response times or larger batches thereby and reduced number of API-calls.
+To pull responses or simplified responses for a survey, the configuration parameters `access_token`, `start_date`, and `survey_id` are required. The parameter `page_size` _(default: 50, max: 100)_ is optional to adjust the response-size for faster response times or larger batches thereby and reduced number of API-calls.
 
 The [surveys](https://developer.surveymonkey.com/api/v3/#surveys-id-details) and [responses](https://developer.surveymonkey.com/api/v3/#surveys-id-responses-bulk) resources will pull data in the form described on the SurveyMonkey API docs.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tap:
 
 To pull all surveys, the configuration parameters `access_token` and `start_date` are required.
 
-To pull responses or simplified responses for a survey, the configuration parameters `access_token`, `start_date`, and `survey_id` are required.
+To pull responses or simplified responses for a survey, the configuration parameters `access_token`, `start_date`, and `survey_id` are required. The parameter `fetch_per_page` _(default: 50, max: 100)_ is optional to adjust the response-size for faster response times or larger batches thereby and reduced number of API-calls.
 
 The [surveys](https://developer.surveymonkey.com/api/v3/#surveys-id-details) and [responses](https://developer.surveymonkey.com/api/v3/#surveys-id-responses-bulk) resources will pull data in the form described on the SurveyMonkey API docs.
 

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,5 +1,6 @@
 {
   "access_token": "EWOooKglj2cM3XZZSf4sVfDehJEF5s4XxRSJ1QcDBwQEeNy8YMliikJzz1Z6R0w.P3vFeTjWpK4ApktA3Quf40R4KKbR8dZgPqxXCEUm3QZyE.MyrvVcSjPll2l6NGAb",
   "start_date": "2017-01-01T00:00:00Z",
-  "survey_id": "112213614"
+  "survey_id": "112213614",
+  "fetch_per_page": "50"
 }

--- a/sample_config.json
+++ b/sample_config.json
@@ -2,5 +2,5 @@
   "access_token": "EWOooKglj2cM3XZZSf4sVfDehJEF5s4XxRSJ1QcDBwQEeNy8YMliikJzz1Z6R0w.P3vFeTjWpK4ApktA3Quf40R4KKbR8dZgPqxXCEUm3QZyE.MyrvVcSjPll2l6NGAb",
   "start_date": "2017-01-01T00:00:00Z",
   "survey_id": "112213614",
-  "fetch_per_page": "50"
+  "fetch_page_size": "50"
 }

--- a/sample_config.json
+++ b/sample_config.json
@@ -2,5 +2,5 @@
   "access_token": "EWOooKglj2cM3XZZSf4sVfDehJEF5s4XxRSJ1QcDBwQEeNy8YMliikJzz1Z6R0w.P3vFeTjWpK4ApktA3Quf40R4KKbR8dZgPqxXCEUm3QZyE.MyrvVcSjPll2l6NGAb",
   "start_date": "2017-01-01T00:00:00Z",
   "survey_id": "112213614",
-  "fetch_page_size": "50"
+  "page_size": "50"
 }

--- a/tap_surveymonkey/mode.py
+++ b/tap_surveymonkey/mode.py
@@ -115,7 +115,7 @@ def patch_time_str(obj_dict):
 def sync_survey_details(config, state):
     stream_id = 'survey_details'
     access_token = config['access_token']
-    per_page = int(config.get("fetch_per_page", "50"))
+    per_page = int(config.get("fetch_page_size", "50"))
     sm_client = SurveyMonkey(access_token)
     params = {
         'per_page': per_page,
@@ -172,7 +172,7 @@ def sync_responses(config, state, simplify=False):
 
     stream_id = 'simplified_responses' if simplify else 'responses'
     access_token = config['access_token']
-    per_page = int(config.get("fetch_per_page", "50"))  # Max 100
+    per_page = int(config.get("fetch_page_size", "50"))  # Max 100
     sm_client = SurveyMonkey(access_token)
     last_modified_at = None
 

--- a/tap_surveymonkey/mode.py
+++ b/tap_surveymonkey/mode.py
@@ -115,7 +115,7 @@ def patch_time_str(obj_dict):
 def sync_survey_details(config, state):
     stream_id = 'survey_details'
     access_token = config['access_token']
-    per_page = int(config.get("fetch_page_size", "50"))
+    per_page = int(config.get("page_size", "50"))
     sm_client = SurveyMonkey(access_token)
     params = {
         'per_page': per_page,
@@ -172,7 +172,7 @@ def sync_responses(config, state, simplify=False):
 
     stream_id = 'simplified_responses' if simplify else 'responses'
     access_token = config['access_token']
-    per_page = int(config.get("fetch_page_size", "50"))  # Max 100
+    per_page = int(config.get("page_size", "50"))  # Max 100
     sm_client = SurveyMonkey(access_token)
     last_modified_at = None
 

--- a/tap_surveymonkey/mode.py
+++ b/tap_surveymonkey/mode.py
@@ -115,9 +115,10 @@ def patch_time_str(obj_dict):
 def sync_survey_details(config, state):
     stream_id = 'survey_details'
     access_token = config['access_token']
+    per_page = int(config.get("fetch_per_page", "50"))
     sm_client = SurveyMonkey(access_token)
     params = {
-        'per_page': 50,
+        'per_page': per_page,
         'page': 1,
         'include': 'date_modified'
     }
@@ -171,6 +172,7 @@ def sync_responses(config, state, simplify=False):
 
     stream_id = 'simplified_responses' if simplify else 'responses'
     access_token = config['access_token']
+    per_page = int(config.get("fetch_per_page", "50"))  # Max 100
     sm_client = SurveyMonkey(access_token)
     last_modified_at = None
 
@@ -181,18 +183,18 @@ def sync_responses(config, state, simplify=False):
         last_modified_at = state['bookmarks'][stream_id]['full_sync']
 
     params = {
-        'page': 1
+        'page': 1,
+        'per_page': per_page
     }
 
     if last_modified_at:
         params['start_modified_at'] = last_modified_at
     if simplify:
         params['simple'] = True
-        responses = sm_client.make_request(
-            'surveys/%s/responses/bulk' % survey_id, params=params, state=state)
-    else:
-        responses = sm_client.make_request(
-            'surveys/%s/responses/bulk' % survey_id, params=params, state=state)
+
+    responses = sm_client.make_request(
+        'surveys/%s/responses/bulk' % survey_id, params=params, state=state)
+
     while True:
         if not responses:
             raise Exception("Resource not found")


### PR DESCRIPTION
# Description of change

I'm running into a limit of nr-api-calls per day, so a small optimization is to use a 100-items per_page fetching.

I have added the config param fetch_per_page which is passed as the per_page paramater in http-request. This allows larger page-sizes and less API-calls.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)

# Risks

# Rollback steps
 - revert this branch
