### PR TITLE
Add missing snickname in schema

### DIFF
--- a/tap_surveymonkey/schemas/survey_details.json
+++ b/tap_surveymonkey/schemas/survey_details.json
@@ -452,6 +452,9 @@
                 "href": {
                   "type": "string"
                 },
+                "nickname": {
+                  "type": "string"
+                },
                 "headings": {
                   "type": "array",
                   "items": {


### PR DESCRIPTION
# Description of change
Fix error like this 
```
Error persisting data to Stitch: 400: {'error': 'Record 109 for table survey_details did not conform to schema:\n#/pages/2/questions/0: extraneous key [nickname] is not permitted\n'}
```

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)

# Risks

# Rollback steps
 - revert this branch
