### PR TITLE
add simple flag in params for simplified responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.1
-  * changes to get `heading` field in response for `simplified_responses` stream [#29](https://github.com/singer-io/tap-surveymonkey/pull/29)
+  * Get `heading` field in response for `simplified_responses` stream [#29](https://github.com/singer-io/tap-surveymonkey/pull/29)
 
 ## 2.0.0
   * Add new stream `surveys` to fetch all the surveys data [#24](https://github.com/singer-io/tap-surveymonkey/pull/24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+  * changes to get `heading` field in response for `simplified_responses` stream [#29](https://github.com/singer-io/tap-surveymonkey/pull/29)
+
 ## 2.0.0
   * Add new stream `surveys` to fetch all the surveys data [#24](https://github.com/singer-io/tap-surveymonkey/pull/24)
   * Add support to extract survey_details, responses and simplified_responses data with/without survey_id

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.0.0",
+    version="2.0.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_surveymonkey/streams.py
+++ b/tap_surveymonkey/streams.py
@@ -231,6 +231,8 @@ class Responses(PaginatedStream):
 
     def get_params(self, stream, config, state, bookmark_value):
         params = super().get_params(stream, config, state, bookmark_value=None)
+        if self.simple:
+            params["simple"] = True
 
         params.update(
             {


### PR DESCRIPTION
# Description of change
- add `simple=True` in params for `simplified_responses` stream to get heading field in response #28 
- bump version changes

# QA steps
 - [X] automated tests passing
 - [ ] manual qa steps passing (list below)

# Risks

# Rollback steps
 - revert this branch
