### PR TITLE
Add missing key_properties node to discover call 

### DIFF
--- a/tap_surveymonkey/discover.py
+++ b/tap_surveymonkey/discover.py
@@ -15,6 +15,7 @@ def get_schemas():
 
     schemas = {}
     schemas_metadata = {}
+    schema_key_properties = {}
 
     for stream_name, stream_object in STREAMS.items():
 
@@ -42,8 +43,9 @@ def get_schemas():
 
         schemas[stream_name] = schema
         schemas_metadata[stream_name] = meta
+        schema_key_properties[stream_name] = stream_object.key_properties
 
-    return schemas, schemas_metadata
+    return schemas, schemas_metadata, schema_key_properties
 
 
 def discover():
@@ -51,18 +53,20 @@ def discover():
     Builds the singer catalog for all the streams in the schemas directory.
     """
 
-    schemas, schemas_metadata = get_schemas()
+    schemas, schemas_metadata, schema_key_properties = get_schemas()
     streams = []
 
 
     for schema_name, schema in schemas.items():
         schema_meta = schemas_metadata[schema_name]
+        key_properties = schema_key_properties[schema_name]
 
         catalog_entry = {
             "stream": schema_name,
             "tap_stream_id": schema_name,
             "schema": schema,
             "metadata": schema_meta,
+            "key_properties": key_properties
         }
 
         streams.append(catalog_entry)


### PR DESCRIPTION
# Description of change

Fix issue where `key_properties` node is missing from discovery call in the output `catalog.json`. This bug was also reported by other users in Issue #31 

## Current Manual Workaround 

A manual workaround was to add `key_properties: "id"` to the generated `catalog.json` file. However, this fix does not work in cases where the user wishes to invoke the tap using `meltano run`, `meltano invoke`, etc. as the Catalog is automatically generated at run time by running the `discover()` function. 

**Note**: Even though you can manually pass in a [generated catalog](https://docs.meltano.com/concepts/plugins/#catalog-extra) to `meltano run`, you lose custom functionality such as being able to `select` and other commands ([Meltano docs](https://docs.meltano.com/concepts/plugins/#select-extra))

## Stream Maps Workaround

- Since this tap is not building using the Meltano SDK, we're unable to use the [Meltano Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html) to update the `key_properties` directly. 
- Despite trying with `meltano-map-transformer` which can be used to support non-SDK taps and targets, the error persists even if you add a `__key_properties__: [id]` to the tap 

<img width="2030" alt="10-04-bv145-b7aro" src="https://github.com/singer-io/tap-surveymonkey/assets/9520975/000b2d51-7b9d-4e81-b818-687dd857a493">


# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)

## Manual QA 

### Failing Scenario (Prod Version) 

<details open>
  <summary>Click to collapse Prod meltano.yml</summary>
  
  ```yaml
plugins:
  extractors:
    - name: tap-surveymonkey
      namespace: tap_surveymonkey
      pip_url: git+https://github.com/singer-io/tap-surveymonkey.git # Use existing prod version
      executable: tap-surveymonkey
      capabilities:
        - discover
        - state
        - catalog
      config:
        start_date: "2010-01-01T00:00:00Z"
        access_token: "my_access_token"
        survey_id: "my_survey_ID"
      select:
        - survey_details.*
```

  </summary>
</details>

<img width="1490" alt="03-11-fcpop-2vn95" src="https://github.com/singer-io/tap-surveymonkey/assets/9520975/0406a321-a837-446b-bd62-73a3bdc56e77">

### Successfully Running (Staging Version) 

<details open>
  <summary>Click to collapse Staging meltano.yml</summary>
  
  ```yaml
plugins:
  extractors:
    - name: tap-surveymonkey
      namespace: tap_surveymonkey
      pip_url: /Users/devanshmalik/Projects/tap-surveymonkey # Use staging version
      executable: tap-surveymonkey
      capabilities:
        - discover
        - state
        - catalog
      config:
        start_date: "2010-01-01T00:00:00Z"
        access_token: "my_access_token"
        survey_id: "my_survey_ID"
      select:
        - survey_details.*
```

  </summary>
</details>

<img width="2522" alt="03-27-szgby-bim7f" src="https://github.com/singer-io/tap-surveymonkey/assets/9520975/1f994d27-e214-46cd-9f8a-a9039bbfc9f3">



# Risks

No risks as the tap is unusable in it's current condition unless the user manually supplies an edited version of `catalog.json` file by adding `key_properties: "id"` to all streams they wish to run. 

# Rollback steps
 - revert this branch
