### PR TITLE
SAC-28163: CircleCI Upgrade, Swap to UV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,16 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-surveymonkey
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-surveymonkey
             source /usr/local/share/virtualenvs/tap-surveymonkey/bin/activate
-            pip install -U pip 'setuptools==65.3.0'
-            pip install .[dev]
+            uv pip install -U pip 'setuptools==65.3.0'
+            uv pip install .[dev]
       - run:
           name: 'pylint'
           command: |
@@ -21,8 +21,8 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-surveymonkey/bin/activate
-            pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
-            nose2 --with-coverage -v -s tests/unittests
+            uv pip install pytest parameterized coverage
+            coverage run -m pytest tests/unittests
 
 workflows:
   version: 2


### PR DESCRIPTION
# Description of change
- Upgrade circleci image
- Swap from pyenv to uv
- Swap from nose to pytest

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)

# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
