### PR TITLE
SAC-28890 metadata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+  * Adding Parent relationship to child streams [#38](https://github.com/singer-io/tap-surveymonkey/pull/38)
+
 ## 2.1.1
   * Updates requests to 2.32.4 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)
   * Updates singer-python to 6.0.1 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.2.0
-  * Adding Parent relationship to child streams [#38](https://github.com/singer-io/tap-surveymonkey/pull/38)
+  * Adding Parent relationship to child streams [#39](https://github.com/singer-io/tap-surveymonkey/pull/39)
 
 ## 2.1.1
   * Updates requests to 2.32.4 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.2.1",
+    version="2.2.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_surveymonkey"],
     install_requires=[
         "singer-python==6.8.0",
-        "requests==2.33.0",
+        "requests==2.34.2",
         "backoff==2.2.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.1.1",
+    version="2.2.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_surveymonkey/discover.py
+++ b/tap_surveymonkey/discover.py
@@ -39,7 +39,11 @@ def get_schemas():
                                       "automatic")
 
         meta = metadata.to_list(meta)
-
+        parent = getattr(stream_object, "parent_stream", None)
+        if parent:
+            parent_id = stream_object.parent_stream.path
+            data = meta[0].get("metadata")
+            data['parent-tap-stream-id'] = parent_id
         schemas[stream_name] = schema
         schemas_metadata[stream_name] = meta
 

--- a/tap_surveymonkey/discover.py
+++ b/tap_surveymonkey/discover.py
@@ -41,8 +41,8 @@ def get_schemas():
         meta = metadata.to_list(meta)
         parent = getattr(stream_object, "parent_stream", None)
         if parent:
-            parent_id = stream_object.parent_stream.path
-            data = meta[0].get("metadata")
+            parent_id = parent.path
+            data = meta[0].setdefault("metadata", {})
             data['parent-tap-stream-id'] = parent_id
         schemas[stream_name] = schema
         schemas_metadata[stream_name] = meta


### PR DESCRIPTION
# Description of change
[SAC-28890](https://qlik-dev.atlassian.net/browse/SAC-28890)

This PR adds parent-child stream relationship metadata to the SurveyMonkey tap by populating the `parent-tap-stream-id` field for child streams, and bumps the version to 2.2.0.

- Adds logic to detect parent streams and set `parent-tap-stream-id` in stream metadata
- Updates version from 2.1.1 to 2.2.0
- Documents the change in CHANGELOG.md

### Changes


| File | Description |
| ---- | ----------- |
| tap_surveymonkey/discover.py | Adds parent stream detection and metadata population logic |
| setup.py | Bumps version to 2.2.0 |
| CHANGELOG.md | Documents the parent relationship feature addition |



# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
