### PR TITLE
Fix TypeError by filtering SurveyStream output to only needed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.2
+  * Fix TypeError in parent_row path substitution [#43](https://github.com/singer-io/tap-surveymonkey/pull/43)
+
 ## 2.1.1
   * Updates requests to 2.32.4 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)
   * Updates singer-python to 6.0.1 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.1.1",
+    version="2.1.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_surveymonkey/streams.py
+++ b/tap_surveymonkey/streams.py
@@ -152,7 +152,7 @@ class SurveyStream(PaginatedStream):
             yield {"id": survey_id}
         else:
             for survey_raw_record in super().fetch_data(client, None, config, state):
-                yield survey_raw_record
+                yield {"id": survey_raw_record["id"], "date_modified": survey_raw_record.get("date_modified")}
 
 
 class Surveys(PaginatedStream):


### PR DESCRIPTION
# Description of change
## Background
When a survey id is not provided in `survey_id` configuration parameter, the list of survey ids is fetched from SurveyMonkey API's `/surveys` endpoint. This allows extracting data from all surveys with one run.
In February 2026 SurveyMonkey API started returning an integer-typed field `response_count` from the `/surveys` endpoint. This is an undocumented change, but SurveyMonkey support has confirmed this as an intended change.

## Issue
The new field in the API response causes a `TypeError: replace() argument 2 must be str, not int` when syncing e.g. `survey_details` or `responses`, because `SurveyStream` passes the full API response as `parent_row` to child streams, and the path substitution loop calls `str.replace()` on every value, including the new non-string one.

## Fix
Fixed by filtering `SurveyStream.fetch_data` to only yield `id` and `date_modified` from parent survey records, which are the only fields used downstream (path substitution and bookmarking).

Solves issue: #42

# QA steps
- [ ] automated tests passing
- [x] manual qa steps passing (list below)
  - [x] run tap against a SurveyMonkey account with `survey_details` selected: no `TypeError`, records synced correctly
  - [x] run tap against a SurveyMonkey account with `responses` selected: no `TypeError`, records synced correctly
  - [x] run tap with `survey_id` set in config: still works as before (only `{"id": survey_id}` yielded)

# Risks
Low. The change only narrows the data passed between internal streams. No external API calls or output schema are affected.

# Rollback steps
- revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool