### PR TITLE
"TypeError: replace() argument 2 must be str, not int" when syncing eg. survey_details or responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.2
+  * Fix TypeError in parent_row path substitution [#43](https://github.com/singer-io/tap-surveymonkey/pull/43)
+
 ## 2.1.1
   * Updates requests to 2.32.4 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)
   * Updates singer-python to 6.0.1 [#35](https://github.com/singer-io/tap-surveymonkey/pull/35)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.1.1",
+    version="2.1.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_surveymonkey/streams.py
+++ b/tap_surveymonkey/streams.py
@@ -152,7 +152,7 @@ class SurveyStream(PaginatedStream):
             yield {"id": survey_id}
         else:
             for survey_raw_record in super().fetch_data(client, None, config, state):
-                yield survey_raw_record
+                yield {"id": survey_raw_record["id"], "date_modified": survey_raw_record.get("date_modified")}
 
 
 class Surveys(PaginatedStream):


### PR DESCRIPTION
# Description of change
- Merge community PR https://github.com/singer-io/tap-surveymonkey/issues/42

# Manual QA steps
 - Ran the unittests on dev environment successfully

 
# Rollback steps
 - revert this branch

