### PR TITLE
[SAC-30903] - CVE Issues Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.3
+  * Bump `requests` to 2.34.2 to address CVE security advisories [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
+  * Bump `urllib3` to 2.7.0 (dev dependency) to fix two HIGH severity CVEs: cross-origin redirect sensitive header leak and compressed response resource exhaustion [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
+
 ## 2.2.2
   * Fix TypeError in parent_row path substitution [#43](https://github.com/singer-io/tap-surveymonkey/pull/43)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.3
   * Bump `requests` to 2.34.2 to address CVE security advisories [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
-  * Bump `urllib3` to 2.7.0 (dev dependency) to fix two HIGH severity CVEs: cross-origin redirect sensitive header leak and compressed response resource exhaustion [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
+  * Bump `urllib3` to 2.7.0 to fix two HIGH severity CVEs: cross-origin redirect sensitive header leak and compressed response resource exhaustion [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
+  * **Breaking change for existing users:** PR [#44](https://github.com/singer-io/tap-surveymonkey/pull/44) introduced explicit `key_properties = ["id"]` for all streams; Singer targets (e.g. BigQuery) that previously ingested data without `key_properties` and stored `__sdc_primary_key` as the primary key must update their primary key metadata to `id` before loading new data
 
 ## 2.2.2
   * Fix TypeError in parent_row path substitution [#43](https://github.com/singer-io/tap-surveymonkey/pull/43)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 3.0.0
   * Bump `requests` to 2.34.2 to address CVE security advisories [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
-  * Bump `urllib3` to 2.7.0 to fix two HIGH severity CVEs: cross-origin redirect sensitive header leak and compressed response resource exhaustion [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
   * **Breaking change for existing users:** PR [#44](https://github.com/singer-io/tap-surveymonkey/pull/44) introduced explicit `key_properties = ["id"]` for all streams; Singer targets (e.g. BigQuery) that previously ingested data without `key_properties` and stored `__sdc_primary_key` as the primary key must update their primary key metadata to `id` before loading new data
 
 ## 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.3
+## 3.0.0
   * Bump `requests` to 2.34.2 to address CVE security advisories [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
   * Bump `urllib3` to 2.7.0 to fix two HIGH severity CVEs: cross-origin redirect sensitive header leak and compressed response resource exhaustion [#48](https://github.com/singer-io/tap-surveymonkey/pull/48)
   * **Breaking change for existing users:** PR [#44](https://github.com/singer-io/tap-surveymonkey/pull/44) introduced explicit `key_properties = ["id"]` for all streams; Singer targets (e.g. BigQuery) that previously ingested data without `key_properties` and stored `__sdc_primary_key` as the primary key must update their primary key metadata to `id` before loading new data

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "singer-python==6.8.0",
         "requests==2.34.2",
         "backoff==2.2.1",
+        "urllib3==2.7.0",
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.2.2",
+    version="2.2.3",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'dev': [
             'ipdb',
             'pylint',
-            'urllib3==2.6.3'
+            'urllib3==2.7.0'
         ]
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_surveymonkey"],
     install_requires=[
         "singer-python==6.8.0",
-        "requests==2.33.0",
+        "requests==2.34.2",
         "backoff==2.2.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-surveymonkey",
-    version="2.2.3",
+    version="3.0.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ setup(
     install_requires=[
         "singer-python==6.8.0",
         "requests==2.34.2",
-        "backoff==2.2.1",
-        "urllib3==2.7.0",
+        "backoff==2.2.1"
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     install_requires=[
         "singer-python==6.8.0",
         "requests==2.34.2",
-        "backoff==2.2.1"
+        "backoff==2.2.1",
+        "urllib3==2.7.0",
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30903



- Bump `requests` `2.33.0` → `2.34.2` to address multiple CVE advisories
- Add `urllib3==2.7.0` to fix 2 open HIGH severity Dependabot alerts:
  - Cross-origin redirect sensitive header leak (`Authorization`, `Cookie`, `Proxy-Authorization` forwarded via low-level `ProxyManager` API)
  - Compressed response resource exhaustion via Brotli / `drain_conn()` (CWE-409)
- Bump version `2.2.2` → `3.0.0`

### Why

Two HIGH severity urllib3 CVEs were blocking compliance checks.

### Breaking Change (from PR [#44](https://github.com/singer-io/tap-surveymonkey/pull/44))

PR #44 introduced explicit `key_properties = ["id"]` for all streams. Existing Singer targets (e.g. BigQuery) that previously stored `__sdc_primary_key` will see a primary key mismatch error on load. The `_sdc_primary_keys` metadata table must be updated to `id` before the next load. 

# Manual QA steps
- [x] Discovery: Passes
- [x] Sync: Passes
- [x] Unit Tests: Passes
- [x] Integration test: Passes
